### PR TITLE
Doc: Use latest rosbridge_suite for working ActionLib Widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,18 +29,17 @@ Until now, it is being developed and tested using Google Chrome browser.
     $ rosdep install web_video_server
     ```
 
-3. [Possibile to skip, but then ActionLib Widget is not working]
-    Install latest development version of rosbrige_server
+3. Install latest development version of rosbrige_server
    ```sh
     $ # go to your catkin workspace /src
     $ git clone -b develop https://github.com/RobotWebTools/rosbridge_suite.git
     $ cd ..
     $ source devel/setup.bash
     $ catkin_make
-    $ # edit src/rosbridge_suite/rosbridge_server/launch/rosbridge_websocket.launch
-      # replace each glob args line of  <arg name="topics_glob" default="[]" /> 
-      # with <arg name="topics_glob" default="[*]" /> 
-      # if you do not add the "*" no topic will be shown!
+    $  # edit src/rosbridge_suite/rosbridge_server/launch/rosbridge_websocket.launch
+    $  # replace each glob args line of  <arg name="topics_glob" default="[]" /> 
+    $  # with <arg name="topics_glob" default="[*]" /> 
+    $  # if you do not add the "*" no topic will be shown!
     $ roslaunch rosbridge_server rosbridge_websocket.launch
     $ rosrun web_video_server web_video_server
     ```

--- a/README.md
+++ b/README.md
@@ -29,13 +29,30 @@ Until now, it is being developed and tested using Google Chrome browser.
     $ rosdep install web_video_server
     ```
 
-3. Launch rosbridge websocket server and web video server
+3. [Possibile to skip, but then ActionLib Widget is not working]
+    Install latest development version of rosbrige_server
+   ```sh
+    $ # go to your catkin workspace /src
+    $ git clone -b develop https://github.com/RobotWebTools/rosbridge_suite.git
+    $ cd ..
+    $ source devel/setup.bash
+    $ catkin_make
+    $ # edit src/rosbridge_suite/rosbridge_server/launch/rosbridge_websocket.launch
+      # replace each glob args line of  <arg name="topics_glob" default="[]" /> 
+      # with <arg name="topics_glob" default="[*]" /> 
+      # if you do not add the "*" no topic will be shown!
+    $ roslaunch rosbridge_server rosbridge_websocket.launch
+    $ rosrun web_video_server web_video_server
+    ```
+ 
+4. Launch rosbridge websocket server and web video server
     ```sh
     $ roslaunch rosbridge_server rosbridge_websocket.launch
     $ rosrun web_video_server web_video_server
     ```
 
-4. Open the [working demo page][demo] (or download it to your computer) and connect to your ROS server (usually ws://localhost:9090)
+5. Open the [working demo page][demo] (or download it to your computer) and connect to your ROS server (usually ws://localhost:9090)
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ Until now, it is being developed and tested using Google Chrome browser.
     $ rosdep install web_video_server
     ```
 
-3. Install latest development version of rosbrige_server
-   ```sh
+
+4. Install latest development version of rosbrige_server [you can skip this, but then the ActionLib Widget is not working]
+    ```sh
     $ # go to your catkin workspace /src
     $ git clone -b develop https://github.com/RobotWebTools/rosbridge_suite.git
     $ cd ..

--- a/src/widgets/camera_viewer/index.hbs
+++ b/src/widgets/camera_viewer/index.hbs
@@ -2,7 +2,7 @@
   data-max-height="600" data-height="360" data-width="480">
 
   <!--  META Tags to describe topics subscription -->
-  <meta data-ros-topic="1" data-ros-topic-id="1" data-ros-topic-desc="Topic to subscribe" data-ros-topic-type="sensor_msgs/Image"
+  <meta data-ros-topic="1" data-ros-topic-id="1" data-ros-topic-desc="Topic to subscribe" data-ros-topic-type="sensor_msgs/Image|sensor_msgs/CompressedImage"
     data-ros-topic-chng="onchange" data-ros-topic-slctd="" />
 
   <!-- The content which could be manipulated by widget class -->


### PR DESCRIPTION
Why? In current rosbridge_suite master the ActionLib Service is not yet implemented. Only in develop branch.
