### PR TITLE
fix a calling of class method clbkCreated.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist/*
 node_modules/*
 typedoc/*
 .vscode/.*
+.idea/

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/src/ts/model/widget_instance.ts
+++ b/src/ts/model/widget_instance.ts
@@ -25,9 +25,9 @@ export class WidgetInstance {
     currentWorkspace.create<WidgetInstance>(this);
 
     // this.WidgetCallbackClass = instance_loader.getInstance<any>(window, "Widget" + widget.alias, this.id);
-    this.WidgetCallbackClass = new window["Widget" + widget.alias](this.id); 
+    this.WidgetCallbackClass = new window["Widget" + widget.alias](this.id);
 
-    frontend.insertWidgetInstance(this, this.WidgetCallbackClass.clbkCreated);
+    frontend.insertWidgetInstance(this, () => this.WidgetCallbackClass.clbkCreated());
   }
 
 }


### PR DESCRIPTION
The topic publisher widget has got clbkCreated method.
If you use this syntax
`frontend.insertWidgetInstance(this, this.WidgetCallbackClass.clbkCreated);`
you can't use this.selector (it's undefined) in the method 
But if you use this syntax
`frontend.insertWidgetInstance(this, () => this.WidgetCallbackClass.clbkCreated());`
no problem